### PR TITLE
textureRasterAffine was named the wrong obfuscated function - use that name for the correct affine texture raster

### DIFF
--- a/src/main/java/jagex3/dash3d/ModelLit.java
+++ b/src/main/java/jagex3/dash3d/ModelLit.java
@@ -1289,9 +1289,9 @@ public class ModelLit extends ModelSource {
 				var8 = this.textureVertexZ[var5];
 			}
 			if (this.faceColourC[face] == -1) {
-				Pix3D.textureTriangleAffine(vertexScreenY[a], vertexScreenY[b], vertexScreenY[c], vertexScreenX[a], vertexScreenX[b], vertexScreenX[c], this.faceColourA[face], this.faceColourA[face], this.faceColourA[face], vertexViewSpaceX[var6], vertexViewSpaceX[var7], vertexViewSpaceX[var8], vertexViewSpaceY[var6], vertexViewSpaceY[var7], vertexViewSpaceY[var8], vertexViewSpaceZ[var6], vertexViewSpaceZ[var7], vertexViewSpaceZ[var8], this.faceTextureId[face]);
+				Pix3D.textureTriangle(vertexScreenY[a], vertexScreenY[b], vertexScreenY[c], vertexScreenX[a], vertexScreenX[b], vertexScreenX[c], this.faceColourA[face], this.faceColourA[face], this.faceColourA[face], vertexViewSpaceX[var6], vertexViewSpaceX[var7], vertexViewSpaceX[var8], vertexViewSpaceY[var6], vertexViewSpaceY[var7], vertexViewSpaceY[var8], vertexViewSpaceZ[var6], vertexViewSpaceZ[var7], vertexViewSpaceZ[var8], this.faceTextureId[face]);
 			} else {
-				Pix3D.textureTriangleAffine(vertexScreenY[a], vertexScreenY[b], vertexScreenY[c], vertexScreenX[a], vertexScreenX[b], vertexScreenX[c], this.faceColourA[face], this.faceColourB[face], this.faceColourC[face], vertexViewSpaceX[var6], vertexViewSpaceX[var7], vertexViewSpaceX[var8], vertexViewSpaceY[var6], vertexViewSpaceY[var7], vertexViewSpaceY[var8], vertexViewSpaceZ[var6], vertexViewSpaceZ[var7], vertexViewSpaceZ[var8], this.faceTextureId[face]);
+				Pix3D.textureTriangle(vertexScreenY[a], vertexScreenY[b], vertexScreenY[c], vertexScreenX[a], vertexScreenX[b], vertexScreenX[c], this.faceColourA[face], this.faceColourB[face], this.faceColourC[face], vertexViewSpaceX[var6], vertexViewSpaceX[var7], vertexViewSpaceX[var8], vertexViewSpaceY[var6], vertexViewSpaceY[var7], vertexViewSpaceY[var8], vertexViewSpaceZ[var6], vertexViewSpaceZ[var7], vertexViewSpaceZ[var8], this.faceTextureId[face]);
 			}
 		} else if (this.faceColourC[face] == -1) {
 			Pix3D.flatTriangle(vertexScreenY[a], vertexScreenY[b], vertexScreenY[c], vertexScreenX[a], vertexScreenX[b], vertexScreenX[c], palette[this.faceColourA[face]]);
@@ -1406,9 +1406,9 @@ public class ModelLit extends ModelSource {
 					var35 = this.textureVertexZ[var32];
 				}
 				if (this.faceColourC[arg0] == -1) {
-					Pix3D.textureTriangleAffine(var29, var30, var31, var26, var27, var28, this.faceColourA[arg0], this.faceColourA[arg0], this.faceColourA[arg0], vertexViewSpaceX[var33], vertexViewSpaceX[var34], vertexViewSpaceX[var35], vertexViewSpaceY[var33], vertexViewSpaceY[var34], vertexViewSpaceY[var35], vertexViewSpaceZ[var33], vertexViewSpaceZ[var34], vertexViewSpaceZ[var35], this.faceTextureId[arg0]);
+					Pix3D.textureTriangle(var29, var30, var31, var26, var27, var28, this.faceColourA[arg0], this.faceColourA[arg0], this.faceColourA[arg0], vertexViewSpaceX[var33], vertexViewSpaceX[var34], vertexViewSpaceX[var35], vertexViewSpaceY[var33], vertexViewSpaceY[var34], vertexViewSpaceY[var35], vertexViewSpaceZ[var33], vertexViewSpaceZ[var34], vertexViewSpaceZ[var35], this.faceTextureId[arg0]);
 				} else {
-					Pix3D.textureTriangleAffine(var29, var30, var31, var26, var27, var28, clippedColour[0], clippedColour[1], clippedColour[2], vertexViewSpaceX[var33], vertexViewSpaceX[var34], vertexViewSpaceX[var35], vertexViewSpaceY[var33], vertexViewSpaceY[var34], vertexViewSpaceY[var35], vertexViewSpaceZ[var33], vertexViewSpaceZ[var34], vertexViewSpaceZ[var35], this.faceTextureId[arg0]);
+					Pix3D.textureTriangle(var29, var30, var31, var26, var27, var28, clippedColour[0], clippedColour[1], clippedColour[2], vertexViewSpaceX[var33], vertexViewSpaceX[var34], vertexViewSpaceX[var35], vertexViewSpaceY[var33], vertexViewSpaceY[var34], vertexViewSpaceY[var35], vertexViewSpaceZ[var33], vertexViewSpaceZ[var34], vertexViewSpaceZ[var35], this.faceTextureId[arg0]);
 				}
 			} else if (this.faceColourC[arg0] == -1) {
 				Pix3D.flatTriangle(var29, var30, var31, var26, var27, var28, palette[this.faceColourA[arg0]]);
@@ -1435,11 +1435,11 @@ public class ModelLit extends ModelSource {
 				}
 				short var40 = this.faceTextureId[arg0];
 				if (this.faceColourC[arg0] == -1) {
-					Pix3D.textureTriangleAffine(var29, var30, var31, var26, var27, var28, this.faceColourA[arg0], this.faceColourA[arg0], this.faceColourA[arg0], vertexViewSpaceX[var37], vertexViewSpaceX[var38], vertexViewSpaceX[var39], vertexViewSpaceY[var37], vertexViewSpaceY[var38], vertexViewSpaceY[var39], vertexViewSpaceZ[var37], vertexViewSpaceZ[var38], vertexViewSpaceZ[var39], var40);
-					Pix3D.textureTriangleAffine(var29, var31, clippedY[3], var26, var28, clippedX[3], this.faceColourA[arg0], this.faceColourA[arg0], this.faceColourA[arg0], vertexViewSpaceX[var37], vertexViewSpaceX[var38], vertexViewSpaceX[var39], vertexViewSpaceY[var37], vertexViewSpaceY[var38], vertexViewSpaceY[var39], vertexViewSpaceZ[var37], vertexViewSpaceZ[var38], vertexViewSpaceZ[var39], var40);
+					Pix3D.textureTriangle(var29, var30, var31, var26, var27, var28, this.faceColourA[arg0], this.faceColourA[arg0], this.faceColourA[arg0], vertexViewSpaceX[var37], vertexViewSpaceX[var38], vertexViewSpaceX[var39], vertexViewSpaceY[var37], vertexViewSpaceY[var38], vertexViewSpaceY[var39], vertexViewSpaceZ[var37], vertexViewSpaceZ[var38], vertexViewSpaceZ[var39], var40);
+					Pix3D.textureTriangle(var29, var31, clippedY[3], var26, var28, clippedX[3], this.faceColourA[arg0], this.faceColourA[arg0], this.faceColourA[arg0], vertexViewSpaceX[var37], vertexViewSpaceX[var38], vertexViewSpaceX[var39], vertexViewSpaceY[var37], vertexViewSpaceY[var38], vertexViewSpaceY[var39], vertexViewSpaceZ[var37], vertexViewSpaceZ[var38], vertexViewSpaceZ[var39], var40);
 				} else {
-					Pix3D.textureTriangleAffine(var29, var30, var31, var26, var27, var28, clippedColour[0], clippedColour[1], clippedColour[2], vertexViewSpaceX[var37], vertexViewSpaceX[var38], vertexViewSpaceX[var39], vertexViewSpaceY[var37], vertexViewSpaceY[var38], vertexViewSpaceY[var39], vertexViewSpaceZ[var37], vertexViewSpaceZ[var38], vertexViewSpaceZ[var39], var40);
-					Pix3D.textureTriangleAffine(var29, var31, clippedY[3], var26, var28, clippedX[3], clippedColour[0], clippedColour[2], clippedColour[3], vertexViewSpaceX[var37], vertexViewSpaceX[var38], vertexViewSpaceX[var39], vertexViewSpaceY[var37], vertexViewSpaceY[var38], vertexViewSpaceY[var39], vertexViewSpaceZ[var37], vertexViewSpaceZ[var38], vertexViewSpaceZ[var39], var40);
+					Pix3D.textureTriangle(var29, var30, var31, var26, var27, var28, clippedColour[0], clippedColour[1], clippedColour[2], vertexViewSpaceX[var37], vertexViewSpaceX[var38], vertexViewSpaceX[var39], vertexViewSpaceY[var37], vertexViewSpaceY[var38], vertexViewSpaceY[var39], vertexViewSpaceZ[var37], vertexViewSpaceZ[var38], vertexViewSpaceZ[var39], var40);
+					Pix3D.textureTriangle(var29, var31, clippedY[3], var26, var28, clippedX[3], clippedColour[0], clippedColour[2], clippedColour[3], vertexViewSpaceX[var37], vertexViewSpaceX[var38], vertexViewSpaceX[var39], vertexViewSpaceY[var37], vertexViewSpaceY[var38], vertexViewSpaceY[var39], vertexViewSpaceZ[var37], vertexViewSpaceZ[var38], vertexViewSpaceZ[var39], var40);
 				}
 			} else if (this.faceColourC[arg0] == -1) {
 				int var41 = palette[this.faceColourA[arg0]];

--- a/src/main/java/jagex3/dash3d/Pix3D.java
+++ b/src/main/java/jagex3/dash3d/Pix3D.java
@@ -1287,7 +1287,6 @@ public class Pix3D extends Pix2D {
 		}
 	}
 
-	// jag::oldscape::dash3d::SoftwarePix3D::TextureTriangleAffine
 	@ObfuscatedName("fx.cp(IIIIIIIIIIIIIIIIIII)V")
 	public static void textureTriangle(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14, int arg15, int arg16, int arg17, int arg18) {
 		int[] var19 = textureProvider.getTexels(arg18);
@@ -1857,7 +1856,6 @@ public class Pix3D extends Pix2D {
 		}
 	}
 
-	// jag::oldscape::dash3d::SoftwarePix3D::TextureRasterAffine
 	@ObfuscatedName("fx.ca([I[IIIIIIIIIIIIII)V")
 	public static void textureRaster(int[] arg0, int[] arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14) {
 		if (hclip) {
@@ -2265,8 +2263,9 @@ public class Pix3D extends Pix2D {
 		} while (var76 > 0);
 	}
 
+	// jag::oldscape::dash3d::SoftwarePix3D::TextureTriangleAffine
 	@ObfuscatedName("fx.co(IIIIIIIIIIIIIIIIIII)V")
-	public static void textureTriangleCorrect(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14, int arg15, int arg16, int arg17, int arg18) {
+	public static void textureTriangleAffine(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14, int arg15, int arg16, int arg17, int arg18) {
 		int[] var19 = textureProvider.getTexels(arg18);
 		if (var19 == null) {
 			int var20 = textureProvider.getAverageRgb(arg18);
@@ -2353,7 +2352,7 @@ public class Pix3D extends Pix2D {
 									if (var56 < 0) {
 										return;
 									}
-									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var58, var50 >> 16, var51 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
+									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var58, var50 >> 16, var51 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
 									var50 += var29;
 									var51 += var28;
 									var48 += var32;
@@ -2363,7 +2362,7 @@ public class Pix3D extends Pix2D {
 									var55 += var47;
 								}
 							}
-							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var58, var50 >> 16, var49 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
+							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var58, var50 >> 16, var49 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
 							var50 += var29;
 							var49 += var27;
 							var48 += var32;
@@ -2384,7 +2383,7 @@ public class Pix3D extends Pix2D {
 									if (var59 < 0) {
 										return;
 									}
-									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var61, var51 >> 16, var50 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
+									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var61, var51 >> 16, var50 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
 									var50 += var29;
 									var51 += var28;
 									var48 += var32;
@@ -2394,7 +2393,7 @@ public class Pix3D extends Pix2D {
 									var55 += var47;
 								}
 							}
-							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var61, var49 >> 16, var50 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
+							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var61, var49 >> 16, var50 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
 							var50 += var29;
 							var49 += var27;
 							var48 += var32;
@@ -2434,7 +2433,7 @@ public class Pix3D extends Pix2D {
 									if (var72 < 0) {
 										return;
 									}
-									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var74, var62 >> 16, var64 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
+									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var74, var62 >> 16, var64 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
 									var64 += var28;
 									var62 += var27;
 									var48 += var32;
@@ -2444,7 +2443,7 @@ public class Pix3D extends Pix2D {
 									var68 += var47;
 								}
 							}
-							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var74, var62 >> 16, var63 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
+							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var74, var62 >> 16, var63 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
 							var63 += var29;
 							var62 += var27;
 							var48 += var32;
@@ -2465,7 +2464,7 @@ public class Pix3D extends Pix2D {
 									if (var69 < 0) {
 										return;
 									}
-									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var71, var64 >> 16, var62 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
+									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var71, var64 >> 16, var62 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
 									var64 += var28;
 									var62 += var27;
 									var48 += var32;
@@ -2475,7 +2474,7 @@ public class Pix3D extends Pix2D {
 									var68 += var47;
 								}
 							}
-							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var71, var63 >> 16, var62 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
+							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var71, var63 >> 16, var62 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
 							var63 += var29;
 							var62 += var27;
 							var48 += var32;
@@ -2526,7 +2525,7 @@ public class Pix3D extends Pix2D {
 									if (var83 < 0) {
 										return;
 									}
-									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var85, var77 >> 16, var78 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
+									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var85, var77 >> 16, var78 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
 									var77 += var27;
 									var78 += var29;
 									var75 += var32;
@@ -2536,7 +2535,7 @@ public class Pix3D extends Pix2D {
 									var82 += var47;
 								}
 							}
-							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var85, var77 >> 16, var76 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
+							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var85, var77 >> 16, var76 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
 							var77 += var27;
 							var76 += var28;
 							var75 += var32;
@@ -2557,7 +2556,7 @@ public class Pix3D extends Pix2D {
 									if (var86 < 0) {
 										return;
 									}
-									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var88, var78 >> 16, var77 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
+									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var88, var78 >> 16, var77 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
 									var77 += var27;
 									var78 += var29;
 									var75 += var32;
@@ -2567,7 +2566,7 @@ public class Pix3D extends Pix2D {
 									var82 += var47;
 								}
 							}
-							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var88, var76 >> 16, var77 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
+							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var88, var76 >> 16, var77 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
 							var77 += var27;
 							var76 += var28;
 							var75 += var32;
@@ -2607,7 +2606,7 @@ public class Pix3D extends Pix2D {
 									if (var96 < 0) {
 										return;
 									}
-									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var98, var91 >> 16, var89 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
+									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var98, var91 >> 16, var89 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
 									var91 += var29;
 									var89 += var28;
 									var75 += var32;
@@ -2617,7 +2616,7 @@ public class Pix3D extends Pix2D {
 									var95 += var47;
 								}
 							}
-							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var98, var90 >> 16, var89 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
+							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var98, var90 >> 16, var89 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
 							var90 += var27;
 							var89 += var28;
 							var75 += var32;
@@ -2638,7 +2637,7 @@ public class Pix3D extends Pix2D {
 									if (var99 < 0) {
 										return;
 									}
-									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var101, var89 >> 16, var91 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
+									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var101, var89 >> 16, var91 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
 									var91 += var29;
 									var89 += var28;
 									var75 += var32;
@@ -2648,7 +2647,7 @@ public class Pix3D extends Pix2D {
 									var95 += var47;
 								}
 							}
-							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var101, var89 >> 16, var90 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
+							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var101, var89 >> 16, var90 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
 							var90 += var27;
 							var89 += var28;
 							var75 += var32;
@@ -2698,7 +2697,7 @@ public class Pix3D extends Pix2D {
 								if (var110 < 0) {
 									return;
 								}
-								textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var112, var104 >> 16, var105 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
+								textureRasterAffine(Pix2D.pixels, var19, 0, 0, var112, var104 >> 16, var105 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
 								var104 += var28;
 								var105 += var27;
 								var102 += var32;
@@ -2708,7 +2707,7 @@ public class Pix3D extends Pix2D {
 								var109 += var47;
 							}
 						}
-						textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var112, var104 >> 16, var103 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
+						textureRasterAffine(Pix2D.pixels, var19, 0, 0, var112, var104 >> 16, var103 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
 						var104 += var28;
 						var103 += var29;
 						var102 += var32;
@@ -2729,7 +2728,7 @@ public class Pix3D extends Pix2D {
 								if (var113 < 0) {
 									return;
 								}
-								textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var115, var105 >> 16, var104 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
+								textureRasterAffine(Pix2D.pixels, var19, 0, 0, var115, var105 >> 16, var104 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
 								var104 += var28;
 								var105 += var27;
 								var102 += var32;
@@ -2739,7 +2738,7 @@ public class Pix3D extends Pix2D {
 								var109 += var47;
 							}
 						}
-						textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var115, var103 >> 16, var104 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
+						textureRasterAffine(Pix2D.pixels, var19, 0, 0, var115, var103 >> 16, var104 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
 						var104 += var28;
 						var103 += var29;
 						var102 += var32;
@@ -2779,7 +2778,7 @@ public class Pix3D extends Pix2D {
 								if (var123 < 0) {
 									return;
 								}
-								textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var125, var118 >> 16, var116 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
+								textureRasterAffine(Pix2D.pixels, var19, 0, 0, var125, var118 >> 16, var116 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
 								var118 += var27;
 								var116 += var29;
 								var102 += var32;
@@ -2789,7 +2788,7 @@ public class Pix3D extends Pix2D {
 								var122 += var47;
 							}
 						}
-						textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var125, var117 >> 16, var116 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
+						textureRasterAffine(Pix2D.pixels, var19, 0, 0, var125, var117 >> 16, var116 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
 						var117 += var28;
 						var116 += var29;
 						var102 += var32;
@@ -2810,7 +2809,7 @@ public class Pix3D extends Pix2D {
 								if (var126 < 0) {
 									return;
 								}
-								textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var128, var116 >> 16, var118 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
+								textureRasterAffine(Pix2D.pixels, var19, 0, 0, var128, var116 >> 16, var118 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
 								var118 += var27;
 								var116 += var29;
 								var102 += var32;
@@ -2820,7 +2819,7 @@ public class Pix3D extends Pix2D {
 								var122 += var47;
 							}
 						}
-						textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var128, var116 >> 16, var117 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
+						textureRasterAffine(Pix2D.pixels, var19, 0, 0, var128, var116 >> 16, var117 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
 						var117 += var28;
 						var116 += var29;
 						var102 += var32;
@@ -2834,8 +2833,9 @@ public class Pix3D extends Pix2D {
 		}
 	}
 
+	// jag::oldscape::dash3d::SoftwarePix3D::TextureRasterAffine
 	@ObfuscatedName("fx.ch([I[IIIIIIIIIIIIII)V")
-	public static void textureRasterCorrect(int[] arg0, int[] arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14) {
+	public static void textureRasterAffine(int[] arg0, int[] arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14) {
 		if (hclip) {
 			if (arg6 > sizeX) {
 				arg6 = sizeX;

--- a/src/main/java/jagex3/dash3d/Pix3D.java
+++ b/src/main/java/jagex3/dash3d/Pix3D.java
@@ -1289,7 +1289,7 @@ public class Pix3D extends Pix2D {
 
 	// jag::oldscape::dash3d::SoftwarePix3D::TextureTriangleAffine
 	@ObfuscatedName("fx.cp(IIIIIIIIIIIIIIIIIII)V")
-	public static void textureTriangleAffine(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14, int arg15, int arg16, int arg17, int arg18) {
+	public static void textureTriangle(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14, int arg15, int arg16, int arg17, int arg18) {
 		int[] var19 = textureProvider.getTexels(arg18);
 		if (var19 == null) {
 			int var20 = textureProvider.getAverageRgb(arg18);
@@ -1336,983 +1336,6 @@ public class Pix3D extends Pix2D {
 		int var44 = arg9 * var35 - arg15 * var33 << 5;
 		int var45 = var34 * var36 - var33 * var37 << 14;
 		int var46 = var35 * var37 - var34 * var38 << 8;
-		int var47 = var33 * var38 - var35 * var36 << 5;
-		if (arg0 <= arg1 && arg0 <= arg2) {
-			if (arg0 < sizeY) {
-				if (arg1 > sizeY) {
-					arg1 = sizeY;
-				}
-				if (arg2 > sizeY) {
-					arg2 = sizeY;
-				}
-				int var48 = (arg6 << 9) - arg3 * var31 + var31;
-				if (arg1 < arg2) {
-					int var49;
-					int var50 = var49 = arg3 << 16;
-					if (arg0 < 0) {
-						var50 -= arg0 * var29;
-						var49 -= arg0 * var27;
-						var48 -= arg0 * var32;
-						arg0 = 0;
-					}
-					int var51 = arg4 << 16;
-					if (arg1 < 0) {
-						var51 -= arg1 * var28;
-						arg1 = 0;
-					}
-					int var52 = arg0 - originY;
-					int var53 = var41 * var52 + var39;
-					int var54 = var44 * var52 + var42;
-					int var55 = var47 * var52 + var45;
-					if (arg0 != arg1 && var29 < var27 || arg0 == arg1 && var29 > var28) {
-						int var56 = arg2 - arg1;
-						int var57 = arg1 - arg0;
-						int var58 = scanline[arg0];
-						while (true) {
-							var57--;
-							if (var57 < 0) {
-								while (true) {
-									var56--;
-									if (var56 < 0) {
-										return;
-									}
-									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var58, var50 >> 16, var51 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
-									var50 += var29;
-									var51 += var28;
-									var48 += var32;
-									var58 += Pix2D.width;
-									var53 += var41;
-									var54 += var44;
-									var55 += var47;
-								}
-							}
-							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var58, var50 >> 16, var49 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
-							var50 += var29;
-							var49 += var27;
-							var48 += var32;
-							var58 += Pix2D.width;
-							var53 += var41;
-							var54 += var44;
-							var55 += var47;
-						}
-					} else {
-						int var59 = arg2 - arg1;
-						int var60 = arg1 - arg0;
-						int var61 = scanline[arg0];
-						while (true) {
-							var60--;
-							if (var60 < 0) {
-								while (true) {
-									var59--;
-									if (var59 < 0) {
-										return;
-									}
-									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var61, var51 >> 16, var50 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
-									var50 += var29;
-									var51 += var28;
-									var48 += var32;
-									var61 += Pix2D.width;
-									var53 += var41;
-									var54 += var44;
-									var55 += var47;
-								}
-							}
-							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var61, var49 >> 16, var50 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
-							var50 += var29;
-							var49 += var27;
-							var48 += var32;
-							var61 += Pix2D.width;
-							var53 += var41;
-							var54 += var44;
-							var55 += var47;
-						}
-					}
-				} else {
-					int var62;
-					int var63 = var62 = arg3 << 16;
-					if (arg0 < 0) {
-						var63 -= arg0 * var29;
-						var62 -= arg0 * var27;
-						var48 -= arg0 * var32;
-						arg0 = 0;
-					}
-					int var64 = arg5 << 16;
-					if (arg2 < 0) {
-						var64 -= arg2 * var28;
-						arg2 = 0;
-					}
-					int var65 = arg0 - originY;
-					int var66 = var41 * var65 + var39;
-					int var67 = var44 * var65 + var42;
-					int var68 = var47 * var65 + var45;
-					if ((arg0 == arg2 || var29 >= var27) && (arg0 != arg2 || var28 <= var27)) {
-						int var72 = arg1 - arg2;
-						int var73 = arg2 - arg0;
-						int var74 = scanline[arg0];
-						while (true) {
-							var73--;
-							if (var73 < 0) {
-								while (true) {
-									var72--;
-									if (var72 < 0) {
-										return;
-									}
-									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var74, var62 >> 16, var64 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
-									var64 += var28;
-									var62 += var27;
-									var48 += var32;
-									var74 += Pix2D.width;
-									var66 += var41;
-									var67 += var44;
-									var68 += var47;
-								}
-							}
-							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var74, var62 >> 16, var63 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
-							var63 += var29;
-							var62 += var27;
-							var48 += var32;
-							var74 += Pix2D.width;
-							var66 += var41;
-							var67 += var44;
-							var68 += var47;
-						}
-					} else {
-						int var69 = arg1 - arg2;
-						int var70 = arg2 - arg0;
-						int var71 = scanline[arg0];
-						while (true) {
-							var70--;
-							if (var70 < 0) {
-								while (true) {
-									var69--;
-									if (var69 < 0) {
-										return;
-									}
-									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var71, var64 >> 16, var62 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
-									var64 += var28;
-									var62 += var27;
-									var48 += var32;
-									var71 += Pix2D.width;
-									var66 += var41;
-									var67 += var44;
-									var68 += var47;
-								}
-							}
-							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var71, var63 >> 16, var62 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
-							var63 += var29;
-							var62 += var27;
-							var48 += var32;
-							var71 += Pix2D.width;
-							var66 += var41;
-							var67 += var44;
-							var68 += var47;
-						}
-					}
-				}
-			}
-		} else if (arg1 <= arg2) {
-			if (arg1 < sizeY) {
-				if (arg2 > sizeY) {
-					arg2 = sizeY;
-				}
-				if (arg0 > sizeY) {
-					arg0 = sizeY;
-				}
-				int var75 = (arg7 << 9) - arg4 * var31 + var31;
-				if (arg2 < arg0) {
-					int var76;
-					int var77 = var76 = arg4 << 16;
-					if (arg1 < 0) {
-						var77 -= arg1 * var27;
-						var76 -= arg1 * var28;
-						var75 -= arg1 * var32;
-						arg1 = 0;
-					}
-					int var78 = arg5 << 16;
-					if (arg2 < 0) {
-						var78 -= arg2 * var29;
-						arg2 = 0;
-					}
-					int var79 = arg1 - originY;
-					int var80 = var41 * var79 + var39;
-					int var81 = var44 * var79 + var42;
-					int var82 = var47 * var79 + var45;
-					if (arg1 != arg2 && var27 < var28 || arg1 == arg2 && var27 > var29) {
-						int var83 = arg0 - arg2;
-						int var84 = arg2 - arg1;
-						int var85 = scanline[arg1];
-						while (true) {
-							var84--;
-							if (var84 < 0) {
-								while (true) {
-									var83--;
-									if (var83 < 0) {
-										return;
-									}
-									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var85, var77 >> 16, var78 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
-									var77 += var27;
-									var78 += var29;
-									var75 += var32;
-									var85 += Pix2D.width;
-									var80 += var41;
-									var81 += var44;
-									var82 += var47;
-								}
-							}
-							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var85, var77 >> 16, var76 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
-							var77 += var27;
-							var76 += var28;
-							var75 += var32;
-							var85 += Pix2D.width;
-							var80 += var41;
-							var81 += var44;
-							var82 += var47;
-						}
-					} else {
-						int var86 = arg0 - arg2;
-						int var87 = arg2 - arg1;
-						int var88 = scanline[arg1];
-						while (true) {
-							var87--;
-							if (var87 < 0) {
-								while (true) {
-									var86--;
-									if (var86 < 0) {
-										return;
-									}
-									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var88, var78 >> 16, var77 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
-									var77 += var27;
-									var78 += var29;
-									var75 += var32;
-									var88 += Pix2D.width;
-									var80 += var41;
-									var81 += var44;
-									var82 += var47;
-								}
-							}
-							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var88, var76 >> 16, var77 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
-							var77 += var27;
-							var76 += var28;
-							var75 += var32;
-							var88 += Pix2D.width;
-							var80 += var41;
-							var81 += var44;
-							var82 += var47;
-						}
-					}
-				} else {
-					int var89;
-					int var90 = var89 = arg4 << 16;
-					if (arg1 < 0) {
-						var90 -= arg1 * var27;
-						var89 -= arg1 * var28;
-						var75 -= arg1 * var32;
-						arg1 = 0;
-					}
-					int var91 = arg3 << 16;
-					if (arg0 < 0) {
-						var91 -= arg0 * var29;
-						arg0 = 0;
-					}
-					int var92 = arg1 - originY;
-					int var93 = var41 * var92 + var39;
-					int var94 = var44 * var92 + var42;
-					int var95 = var47 * var92 + var45;
-					if (var27 < var28) {
-						int var96 = arg2 - arg0;
-						int var97 = arg0 - arg1;
-						int var98 = scanline[arg1];
-						while (true) {
-							var97--;
-							if (var97 < 0) {
-								while (true) {
-									var96--;
-									if (var96 < 0) {
-										return;
-									}
-									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var98, var91 >> 16, var89 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
-									var91 += var29;
-									var89 += var28;
-									var75 += var32;
-									var98 += Pix2D.width;
-									var93 += var41;
-									var94 += var44;
-									var95 += var47;
-								}
-							}
-							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var98, var90 >> 16, var89 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
-							var90 += var27;
-							var89 += var28;
-							var75 += var32;
-							var98 += Pix2D.width;
-							var93 += var41;
-							var94 += var44;
-							var95 += var47;
-						}
-					} else {
-						int var99 = arg2 - arg0;
-						int var100 = arg0 - arg1;
-						int var101 = scanline[arg1];
-						while (true) {
-							var100--;
-							if (var100 < 0) {
-								while (true) {
-									var99--;
-									if (var99 < 0) {
-										return;
-									}
-									textureRasterAffine(Pix2D.pixels, var19, 0, 0, var101, var89 >> 16, var91 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
-									var91 += var29;
-									var89 += var28;
-									var75 += var32;
-									var101 += Pix2D.width;
-									var93 += var41;
-									var94 += var44;
-									var95 += var47;
-								}
-							}
-							textureRasterAffine(Pix2D.pixels, var19, 0, 0, var101, var89 >> 16, var90 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
-							var90 += var27;
-							var89 += var28;
-							var75 += var32;
-							var101 += Pix2D.width;
-							var93 += var41;
-							var94 += var44;
-							var95 += var47;
-						}
-					}
-				}
-			}
-		} else if (arg2 < sizeY) {
-			if (arg0 > sizeY) {
-				arg0 = sizeY;
-			}
-			if (arg1 > sizeY) {
-				arg1 = sizeY;
-			}
-			int var102 = (arg8 << 9) - arg5 * var31 + var31;
-			if (arg0 < arg1) {
-				int var103;
-				int var104 = var103 = arg5 << 16;
-				if (arg2 < 0) {
-					var104 -= arg2 * var28;
-					var103 -= arg2 * var29;
-					var102 -= arg2 * var32;
-					arg2 = 0;
-				}
-				int var105 = arg3 << 16;
-				if (arg0 < 0) {
-					var105 -= arg0 * var27;
-					arg0 = 0;
-				}
-				int var106 = arg2 - originY;
-				int var107 = var41 * var106 + var39;
-				int var108 = var44 * var106 + var42;
-				int var109 = var47 * var106 + var45;
-				if (var28 < var29) {
-					int var110 = arg1 - arg0;
-					int var111 = arg0 - arg2;
-					int var112 = scanline[arg2];
-					while (true) {
-						var111--;
-						if (var111 < 0) {
-							while (true) {
-								var110--;
-								if (var110 < 0) {
-									return;
-								}
-								textureRasterAffine(Pix2D.pixels, var19, 0, 0, var112, var104 >> 16, var105 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
-								var104 += var28;
-								var105 += var27;
-								var102 += var32;
-								var112 += Pix2D.width;
-								var107 += var41;
-								var108 += var44;
-								var109 += var47;
-							}
-						}
-						textureRasterAffine(Pix2D.pixels, var19, 0, 0, var112, var104 >> 16, var103 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
-						var104 += var28;
-						var103 += var29;
-						var102 += var32;
-						var112 += Pix2D.width;
-						var107 += var41;
-						var108 += var44;
-						var109 += var47;
-					}
-				} else {
-					int var113 = arg1 - arg0;
-					int var114 = arg0 - arg2;
-					int var115 = scanline[arg2];
-					while (true) {
-						var114--;
-						if (var114 < 0) {
-							while (true) {
-								var113--;
-								if (var113 < 0) {
-									return;
-								}
-								textureRasterAffine(Pix2D.pixels, var19, 0, 0, var115, var105 >> 16, var104 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
-								var104 += var28;
-								var105 += var27;
-								var102 += var32;
-								var115 += Pix2D.width;
-								var107 += var41;
-								var108 += var44;
-								var109 += var47;
-							}
-						}
-						textureRasterAffine(Pix2D.pixels, var19, 0, 0, var115, var103 >> 16, var104 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
-						var104 += var28;
-						var103 += var29;
-						var102 += var32;
-						var115 += Pix2D.width;
-						var107 += var41;
-						var108 += var44;
-						var109 += var47;
-					}
-				}
-			} else {
-				int var116;
-				int var117 = var116 = arg5 << 16;
-				if (arg2 < 0) {
-					var117 -= arg2 * var28;
-					var116 -= arg2 * var29;
-					var102 -= arg2 * var32;
-					arg2 = 0;
-				}
-				int var118 = arg4 << 16;
-				if (arg1 < 0) {
-					var118 -= arg1 * var27;
-					arg1 = 0;
-				}
-				int var119 = arg2 - originY;
-				int var120 = var41 * var119 + var39;
-				int var121 = var44 * var119 + var42;
-				int var122 = var47 * var119 + var45;
-				if (var28 < var29) {
-					int var123 = arg0 - arg1;
-					int var124 = arg1 - arg2;
-					int var125 = scanline[arg2];
-					while (true) {
-						var124--;
-						if (var124 < 0) {
-							while (true) {
-								var123--;
-								if (var123 < 0) {
-									return;
-								}
-								textureRasterAffine(Pix2D.pixels, var19, 0, 0, var125, var118 >> 16, var116 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
-								var118 += var27;
-								var116 += var29;
-								var102 += var32;
-								var125 += Pix2D.width;
-								var120 += var41;
-								var121 += var44;
-								var122 += var47;
-							}
-						}
-						textureRasterAffine(Pix2D.pixels, var19, 0, 0, var125, var117 >> 16, var116 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
-						var117 += var28;
-						var116 += var29;
-						var102 += var32;
-						var125 += Pix2D.width;
-						var120 += var41;
-						var121 += var44;
-						var122 += var47;
-					}
-				} else {
-					int var126 = arg0 - arg1;
-					int var127 = arg1 - arg2;
-					int var128 = scanline[arg2];
-					while (true) {
-						var127--;
-						if (var127 < 0) {
-							while (true) {
-								var126--;
-								if (var126 < 0) {
-									return;
-								}
-								textureRasterAffine(Pix2D.pixels, var19, 0, 0, var128, var116 >> 16, var118 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
-								var118 += var27;
-								var116 += var29;
-								var102 += var32;
-								var128 += Pix2D.width;
-								var120 += var41;
-								var121 += var44;
-								var122 += var47;
-							}
-						}
-						textureRasterAffine(Pix2D.pixels, var19, 0, 0, var128, var116 >> 16, var117 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
-						var117 += var28;
-						var116 += var29;
-						var102 += var32;
-						var128 += Pix2D.width;
-						var120 += var41;
-						var121 += var44;
-						var122 += var47;
-					}
-				}
-			}
-		}
-	}
-
-	// jag::oldscape::dash3d::SoftwarePix3D::TextureRasterAffine
-	@ObfuscatedName("fx.ca([I[IIIIIIIIIIIIII)V")
-	public static void textureRasterAffine(int[] arg0, int[] arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14) {
-		if (hclip) {
-			if (arg6 > sizeX) {
-				arg6 = sizeX;
-			}
-			if (arg5 < 0) {
-				arg5 = 0;
-			}
-		}
-		if (arg5 >= arg6) {
-			return;
-		}
-		int var15 = arg4 + arg5;
-		int var16 = arg5 * arg8 + arg7;
-		int var17 = arg6 - arg5;
-		int var10000;
-		if (!lowMem) {
-			int var78 = arg5 - originX;
-			int var79 = (arg12 >> 3) * var78 + arg9;
-			int var80 = (arg13 >> 3) * var78 + arg10;
-			int var81 = (arg14 >> 3) * var78 + arg11;
-			int var82 = var81 >> 14;
-			int var83;
-			int var84;
-			if (var82 == 0) {
-				var83 = 0;
-				var84 = 0;
-			} else {
-				var83 = var79 / var82;
-				var84 = var80 / var82;
-				if (var83 < 0) {
-					var83 = 0;
-				} else if (var83 > 16256) {
-					var83 = 16256;
-				}
-			}
-			int var85 = arg12 + var79;
-			int var86 = arg13 + var80;
-			int var87 = arg14 + var81;
-			int var88 = var87 >> 14;
-			int var89;
-			int var90;
-			if (var88 == 0) {
-				var89 = 0;
-				var90 = 0;
-			} else {
-				var89 = var85 / var88;
-				var90 = var86 / var88;
-				if (var89 < 0) {
-					var89 = 0;
-				} else if (var89 > 16256) {
-					var89 = 16256;
-				}
-			}
-			int var91 = (var83 << 18) + var84;
-			int var92 = (var89 - var83 >> 3 << 18) + (var90 - var84 >> 3);
-			int var93 = var17 >> 3;
-			int var94 = arg8 << 3;
-			int var95 = var16 >> 8;
-			if (opaque) {
-				if (var93 > 0) {
-					do {
-						int var96 = arg1[(var91 >>> 25) + (var91 & 0x3F80)];
-						arg0[var15++] = ((var96 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var96 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						int var97 = var91 + var92;
-						int var98 = arg1[(var97 >>> 25) + (var97 & 0x3F80)];
-						arg0[var15++] = ((var98 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var98 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						int var99 = var92 + var97;
-						int var100 = arg1[(var99 >>> 25) + (var99 & 0x3F80)];
-						arg0[var15++] = ((var100 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var100 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						int var101 = var92 + var99;
-						int var102 = arg1[(var101 >>> 25) + (var101 & 0x3F80)];
-						arg0[var15++] = ((var102 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var102 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						int var103 = var92 + var101;
-						int var104 = arg1[(var103 >>> 25) + (var103 & 0x3F80)];
-						arg0[var15++] = ((var104 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var104 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						int var105 = var92 + var103;
-						int var106 = arg1[(var105 >>> 25) + (var105 & 0x3F80)];
-						arg0[var15++] = ((var106 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var106 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						int var107 = var92 + var105;
-						int var108 = arg1[(var107 >>> 25) + (var107 & 0x3F80)];
-						arg0[var15++] = ((var108 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var108 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						int var109 = var92 + var107;
-						int var110 = arg1[(var109 >>> 25) + (var109 & 0x3F80)];
-						arg0[var15++] = ((var110 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var110 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						var10000 = var92 + var109;
-						int var112 = var89;
-						int var113 = var90;
-						var85 += arg12;
-						var86 += arg13;
-						var87 += arg14;
-						int var114 = var87 >> 14;
-						if (var114 == 0) {
-							var89 = 0;
-							var90 = 0;
-						} else {
-							var89 = var85 / var114;
-							var90 = var86 / var114;
-							if (var89 < 0) {
-								var89 = 0;
-							} else if (var89 > 16256) {
-								var89 = 16256;
-							}
-						}
-						var91 = (var112 << 18) + var113;
-						var92 = (var89 - var112 >> 3 << 18) + (var90 - var113 >> 3);
-						var16 += var94;
-						var95 = var16 >> 8;
-						var93--;
-					} while (var93 > 0);
-				}
-				int var115 = arg6 - arg5 & 0x7;
-				if (var115 > 0) {
-					do {
-						int var116 = arg1[(var91 >>> 25) + (var91 & 0x3F80)];
-						arg0[var15++] = ((var116 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var116 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						var91 += var92;
-						var115--;
-					} while (var115 > 0);
-				}
-			} else {
-				if (var93 > 0) {
-					do {
-						int var117;
-						if ((var117 = arg1[(var91 >>> 25) + (var91 & 0x3F80)]) != 0) {
-							arg0[var15] = ((var117 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var117 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						}
-						var15++;
-						int var118 = var91 + var92;
-						int var119;
-						if ((var119 = arg1[(var118 >>> 25) + (var118 & 0x3F80)]) != 0) {
-							arg0[var15] = ((var119 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var119 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						}
-						var15++;
-						int var120 = var92 + var118;
-						int var121;
-						if ((var121 = arg1[(var120 >>> 25) + (var120 & 0x3F80)]) != 0) {
-							arg0[var15] = ((var121 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var121 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						}
-						var15++;
-						int var122 = var92 + var120;
-						int var123;
-						if ((var123 = arg1[(var122 >>> 25) + (var122 & 0x3F80)]) != 0) {
-							arg0[var15] = ((var123 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var123 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						}
-						var15++;
-						int var124 = var92 + var122;
-						int var125;
-						if ((var125 = arg1[(var124 >>> 25) + (var124 & 0x3F80)]) != 0) {
-							arg0[var15] = ((var125 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var125 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						}
-						var15++;
-						int var126 = var92 + var124;
-						int var127;
-						if ((var127 = arg1[(var126 >>> 25) + (var126 & 0x3F80)]) != 0) {
-							arg0[var15] = ((var127 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var127 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						}
-						var15++;
-						int var128 = var92 + var126;
-						int var129;
-						if ((var129 = arg1[(var128 >>> 25) + (var128 & 0x3F80)]) != 0) {
-							arg0[var15] = ((var129 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var129 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						}
-						var15++;
-						int var130 = var92 + var128;
-						int var131;
-						if ((var131 = arg1[(var130 >>> 25) + (var130 & 0x3F80)]) != 0) {
-							arg0[var15] = ((var131 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var131 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						}
-						var15++;
-						var10000 = var92 + var130;
-						int var133 = var89;
-						int var134 = var90;
-						var85 += arg12;
-						var86 += arg13;
-						var87 += arg14;
-						int var135 = var87 >> 14;
-						if (var135 == 0) {
-							var89 = 0;
-							var90 = 0;
-						} else {
-							var89 = var85 / var135;
-							var90 = var86 / var135;
-							if (var89 < 0) {
-								var89 = 0;
-							} else if (var89 > 16256) {
-								var89 = 16256;
-							}
-						}
-						var91 = (var133 << 18) + var134;
-						var92 = (var89 - var133 >> 3 << 18) + (var90 - var134 >> 3);
-						var16 += var94;
-						var95 = var16 >> 8;
-						var93--;
-					} while (var93 > 0);
-				}
-				int var136 = arg6 - arg5 & 0x7;
-				if (var136 > 0) {
-					do {
-						int var137;
-						if ((var137 = arg1[(var91 >>> 25) + (var91 & 0x3F80)]) != 0) {
-							arg0[var15] = ((var137 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var137 & 0xFF00) * var95 & 0xFF0000) >> 8;
-						}
-						var15++;
-						var91 += var92;
-						var136--;
-					} while (var136 > 0);
-				}
-			}
-			return;
-		}
-		int var18 = arg5 - originX;
-		int var19 = (arg12 >> 3) * var18 + arg9;
-		int var20 = (arg13 >> 3) * var18 + arg10;
-		int var21 = (arg14 >> 3) * var18 + arg11;
-		int var22 = var21 >> 12;
-		int var23;
-		int var24;
-		if (var22 == 0) {
-			var23 = 0;
-			var24 = 0;
-		} else {
-			var23 = var19 / var22;
-			var24 = var20 / var22;
-			if (var23 < 0) {
-				var23 = 0;
-			} else if (var23 > 4032) {
-				var23 = 4032;
-			}
-		}
-		int var25 = arg12 + var19;
-		int var26 = arg13 + var20;
-		int var27 = arg14 + var21;
-		int var28 = var27 >> 12;
-		int var29;
-		int var30;
-		if (var28 == 0) {
-			var29 = 0;
-			var30 = 0;
-		} else {
-			var29 = var25 / var28;
-			var30 = var26 / var28;
-			if (var29 < 0) {
-				var29 = 0;
-			} else if (var29 > 4032) {
-				var29 = 4032;
-			}
-		}
-		int var31 = (var23 << 20) + var24;
-		int var32 = (var29 - var23 >> 3 << 20) + (var30 - var24 >> 3);
-		int var33 = var17 >> 3;
-		int var34 = arg8 << 3;
-		int var35 = var16 >> 8;
-		if (opaque) {
-			if (var33 > 0) {
-				do {
-					int var36 = arg1[(var31 >>> 26) + (var31 & 0xFC0)];
-					arg0[var15++] = ((var36 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var36 & 0xFF00) * var35 & 0xFF0000) >> 8;
-					int var37 = var31 + var32;
-					int var38 = arg1[(var37 >>> 26) + (var37 & 0xFC0)];
-					arg0[var15++] = ((var38 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var38 & 0xFF00) * var35 & 0xFF0000) >> 8;
-					int var39 = var32 + var37;
-					int var40 = arg1[(var39 >>> 26) + (var39 & 0xFC0)];
-					arg0[var15++] = ((var40 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var40 & 0xFF00) * var35 & 0xFF0000) >> 8;
-					int var41 = var32 + var39;
-					int var42 = arg1[(var41 >>> 26) + (var41 & 0xFC0)];
-					arg0[var15++] = ((var42 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var42 & 0xFF00) * var35 & 0xFF0000) >> 8;
-					int var43 = var32 + var41;
-					int var44 = arg1[(var43 >>> 26) + (var43 & 0xFC0)];
-					arg0[var15++] = ((var44 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var44 & 0xFF00) * var35 & 0xFF0000) >> 8;
-					int var45 = var32 + var43;
-					int var46 = arg1[(var45 >>> 26) + (var45 & 0xFC0)];
-					arg0[var15++] = ((var46 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var46 & 0xFF00) * var35 & 0xFF0000) >> 8;
-					int var47 = var32 + var45;
-					int var48 = arg1[(var47 >>> 26) + (var47 & 0xFC0)];
-					arg0[var15++] = ((var48 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var48 & 0xFF00) * var35 & 0xFF0000) >> 8;
-					int var49 = var32 + var47;
-					int var50 = arg1[(var49 >>> 26) + (var49 & 0xFC0)];
-					arg0[var15++] = ((var50 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var50 & 0xFF00) * var35 & 0xFF0000) >> 8;
-					var10000 = var32 + var49;
-					int var52 = var29;
-					int var53 = var30;
-					var25 += arg12;
-					var26 += arg13;
-					var27 += arg14;
-					int var54 = var27 >> 12;
-					if (var54 == 0) {
-						var29 = 0;
-						var30 = 0;
-					} else {
-						var29 = var25 / var54;
-						var30 = var26 / var54;
-						if (var29 < 0) {
-							var29 = 0;
-						} else if (var29 > 4032) {
-							var29 = 4032;
-						}
-					}
-					var31 = (var52 << 20) + var53;
-					var32 = (var29 - var52 >> 3 << 20) + (var30 - var53 >> 3);
-					var16 += var34;
-					var35 = var16 >> 8;
-					var33--;
-				} while (var33 > 0);
-			}
-			int var55 = arg6 - arg5 & 0x7;
-			if (var55 > 0) {
-				do {
-					int var56 = arg1[(var31 >>> 26) + (var31 & 0xFC0)];
-					arg0[var15++] = ((var56 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var56 & 0xFF00) * var35 & 0xFF0000) >> 8;
-					var31 += var32;
-					var55--;
-				} while (var55 > 0);
-			}
-			return;
-		}
-		if (var33 > 0) {
-			do {
-				int var57;
-				if ((var57 = arg1[(var31 >>> 26) + (var31 & 0xFC0)]) != 0) {
-					arg0[var15] = ((var57 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var57 & 0xFF00) * var35 & 0xFF0000) >> 8;
-				}
-				var15++;
-				int var58 = var31 + var32;
-				int var59;
-				if ((var59 = arg1[(var58 >>> 26) + (var58 & 0xFC0)]) != 0) {
-					arg0[var15] = ((var59 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var59 & 0xFF00) * var35 & 0xFF0000) >> 8;
-				}
-				var15++;
-				int var60 = var32 + var58;
-				int var61;
-				if ((var61 = arg1[(var60 >>> 26) + (var60 & 0xFC0)]) != 0) {
-					arg0[var15] = ((var61 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var61 & 0xFF00) * var35 & 0xFF0000) >> 8;
-				}
-				var15++;
-				int var62 = var32 + var60;
-				int var63;
-				if ((var63 = arg1[(var62 >>> 26) + (var62 & 0xFC0)]) != 0) {
-					arg0[var15] = ((var63 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var63 & 0xFF00) * var35 & 0xFF0000) >> 8;
-				}
-				var15++;
-				int var64 = var32 + var62;
-				int var65;
-				if ((var65 = arg1[(var64 >>> 26) + (var64 & 0xFC0)]) != 0) {
-					arg0[var15] = ((var65 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var65 & 0xFF00) * var35 & 0xFF0000) >> 8;
-				}
-				var15++;
-				int var66 = var32 + var64;
-				int var67;
-				if ((var67 = arg1[(var66 >>> 26) + (var66 & 0xFC0)]) != 0) {
-					arg0[var15] = ((var67 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var67 & 0xFF00) * var35 & 0xFF0000) >> 8;
-				}
-				var15++;
-				int var68 = var32 + var66;
-				int var69;
-				if ((var69 = arg1[(var68 >>> 26) + (var68 & 0xFC0)]) != 0) {
-					arg0[var15] = ((var69 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var69 & 0xFF00) * var35 & 0xFF0000) >> 8;
-				}
-				var15++;
-				int var70 = var32 + var68;
-				int var71;
-				if ((var71 = arg1[(var70 >>> 26) + (var70 & 0xFC0)]) != 0) {
-					arg0[var15] = ((var71 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var71 & 0xFF00) * var35 & 0xFF0000) >> 8;
-				}
-				var15++;
-				var10000 = var32 + var70;
-				int var73 = var29;
-				int var74 = var30;
-				var25 += arg12;
-				var26 += arg13;
-				var27 += arg14;
-				int var75 = var27 >> 12;
-				if (var75 == 0) {
-					var29 = 0;
-					var30 = 0;
-				} else {
-					var29 = var25 / var75;
-					var30 = var26 / var75;
-					if (var29 < 0) {
-						var29 = 0;
-					} else if (var29 > 4032) {
-						var29 = 4032;
-					}
-				}
-				var31 = (var73 << 20) + var74;
-				var32 = (var29 - var73 >> 3 << 20) + (var30 - var74 >> 3);
-				var16 += var34;
-				var35 = var16 >> 8;
-				var33--;
-			} while (var33 > 0);
-		}
-		int var76 = arg6 - arg5 & 0x7;
-		if (var76 <= 0) {
-			return;
-		}
-		do {
-			int var77;
-			if ((var77 = arg1[(var31 >>> 26) + (var31 & 0xFC0)]) != 0) {
-				arg0[var15] = ((var77 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var77 & 0xFF00) * var35 & 0xFF0000) >> 8;
-			}
-			var15++;
-			var31 += var32;
-			var76--;
-		} while (var76 > 0);
-	}
-
-	@ObfuscatedName("fx.co(IIIIIIIIIIIIIIIIIII)V")
-	public static void textureTriangle(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14, int arg15, int arg16, int arg17, int arg18) {
-		int[] var19 = textureProvider.getTexels(arg18);
-		if (var19 == null) {
-			int var20 = textureProvider.getAverageRgb(arg18);
-			gouraudTriangle(arg0, arg1, arg2, arg3, arg4, arg5, textureLightColour(var20, arg6), textureLightColour(var20, arg7), textureLightColour(var20, arg8));
-			return;
-		}
-		lowMem = textureProvider.isLowMem(arg18);
-		opaque = textureProvider.isOpaque(arg18);
-		int var21 = arg4 - arg3;
-		int var22 = arg1 - arg0;
-		int var23 = arg5 - arg3;
-		int var24 = arg2 - arg0;
-		int var25 = arg7 - arg6;
-		int var26 = arg8 - arg6;
-		int var27 = 0;
-		if (arg0 != arg1) {
-			var27 = (arg4 - arg3 << 16) / (arg1 - arg0);
-		}
-		int var28 = 0;
-		if (arg1 != arg2) {
-			var28 = (arg5 - arg4 << 16) / (arg2 - arg1);
-		}
-		int var29 = 0;
-		if (arg0 != arg2) {
-			var29 = (arg3 - arg5 << 16) / (arg0 - arg2);
-		}
-		int var30 = var21 * var24 - var22 * var23;
-		if (var30 == 0) {
-			return;
-		}
-		int var31 = (var24 * var25 - var22 * var26 << 9) / var30;
-		int var32 = (var21 * var26 - var23 * var25 << 9) / var30;
-		int var33 = arg9 - arg10;
-		int var34 = arg12 - arg13;
-		int var35 = arg15 - arg16;
-		int var36 = arg11 - arg9;
-		int var37 = arg14 - arg12;
-		int var38 = arg17 - arg15;
-		int var39 = arg12 * var36 - arg9 * var37 << 14;
-		int var40 = arg15 * var37 - arg12 * var38 << 5;
-		int var41 = arg9 * var38 - arg15 * var36 << 5;
-		int var42 = arg12 * var33 - arg9 * var34 << 14;
-		int var43 = arg15 * var34 - arg12 * var35 << 5;
-		int var44 = arg9 * var35 - arg15 * var33 << 5;
-		int var45 = var34 * var36 - var33 * var37 << 14;
-		int var46 = var35 * var37 - var34 * var38 << 5;
 		int var47 = var33 * var38 - var35 * var36 << 5;
 		if (arg0 <= arg1 && arg0 <= arg2) {
 			if (arg0 < sizeY) {
@@ -2834,8 +1857,985 @@ public class Pix3D extends Pix2D {
 		}
 	}
 
-	@ObfuscatedName("fx.ch([I[IIIIIIIIIIIIII)V")
+	// jag::oldscape::dash3d::SoftwarePix3D::TextureRasterAffine
+	@ObfuscatedName("fx.ca([I[IIIIIIIIIIIIII)V")
 	public static void textureRaster(int[] arg0, int[] arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14) {
+		if (hclip) {
+			if (arg6 > sizeX) {
+				arg6 = sizeX;
+			}
+			if (arg5 < 0) {
+				arg5 = 0;
+			}
+		}
+		if (arg5 >= arg6) {
+			return;
+		}
+		int var15 = arg4 + arg5;
+		int var16 = arg5 * arg8 + arg7;
+		int var17 = arg6 - arg5;
+		int var10000;
+		if (!lowMem) {
+			int var78 = arg5 - originX;
+			int var79 = (arg12 >> 3) * var78 + arg9;
+			int var80 = (arg13 >> 3) * var78 + arg10;
+			int var81 = (arg14 >> 3) * var78 + arg11;
+			int var82 = var81 >> 14;
+			int var83;
+			int var84;
+			if (var82 == 0) {
+				var83 = 0;
+				var84 = 0;
+			} else {
+				var83 = var79 / var82;
+				var84 = var80 / var82;
+				if (var83 < 0) {
+					var83 = 0;
+				} else if (var83 > 16256) {
+					var83 = 16256;
+				}
+			}
+			int var85 = arg12 + var79;
+			int var86 = arg13 + var80;
+			int var87 = arg14 + var81;
+			int var88 = var87 >> 14;
+			int var89;
+			int var90;
+			if (var88 == 0) {
+				var89 = 0;
+				var90 = 0;
+			} else {
+				var89 = var85 / var88;
+				var90 = var86 / var88;
+				if (var89 < 0) {
+					var89 = 0;
+				} else if (var89 > 16256) {
+					var89 = 16256;
+				}
+			}
+			int var91 = (var83 << 18) + var84;
+			int var92 = (var89 - var83 >> 3 << 18) + (var90 - var84 >> 3);
+			int var93 = var17 >> 3;
+			int var94 = arg8 << 3;
+			int var95 = var16 >> 8;
+			if (opaque) {
+				if (var93 > 0) {
+					do {
+						int var96 = arg1[(var91 >>> 25) + (var91 & 0x3F80)];
+						arg0[var15++] = ((var96 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var96 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						int var97 = var91 + var92;
+						int var98 = arg1[(var97 >>> 25) + (var97 & 0x3F80)];
+						arg0[var15++] = ((var98 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var98 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						int var99 = var92 + var97;
+						int var100 = arg1[(var99 >>> 25) + (var99 & 0x3F80)];
+						arg0[var15++] = ((var100 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var100 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						int var101 = var92 + var99;
+						int var102 = arg1[(var101 >>> 25) + (var101 & 0x3F80)];
+						arg0[var15++] = ((var102 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var102 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						int var103 = var92 + var101;
+						int var104 = arg1[(var103 >>> 25) + (var103 & 0x3F80)];
+						arg0[var15++] = ((var104 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var104 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						int var105 = var92 + var103;
+						int var106 = arg1[(var105 >>> 25) + (var105 & 0x3F80)];
+						arg0[var15++] = ((var106 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var106 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						int var107 = var92 + var105;
+						int var108 = arg1[(var107 >>> 25) + (var107 & 0x3F80)];
+						arg0[var15++] = ((var108 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var108 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						int var109 = var92 + var107;
+						int var110 = arg1[(var109 >>> 25) + (var109 & 0x3F80)];
+						arg0[var15++] = ((var110 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var110 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						var10000 = var92 + var109;
+						int var112 = var89;
+						int var113 = var90;
+						var85 += arg12;
+						var86 += arg13;
+						var87 += arg14;
+						int var114 = var87 >> 14;
+						if (var114 == 0) {
+							var89 = 0;
+							var90 = 0;
+						} else {
+							var89 = var85 / var114;
+							var90 = var86 / var114;
+							if (var89 < 0) {
+								var89 = 0;
+							} else if (var89 > 16256) {
+								var89 = 16256;
+							}
+						}
+						var91 = (var112 << 18) + var113;
+						var92 = (var89 - var112 >> 3 << 18) + (var90 - var113 >> 3);
+						var16 += var94;
+						var95 = var16 >> 8;
+						var93--;
+					} while (var93 > 0);
+				}
+				int var115 = arg6 - arg5 & 0x7;
+				if (var115 > 0) {
+					do {
+						int var116 = arg1[(var91 >>> 25) + (var91 & 0x3F80)];
+						arg0[var15++] = ((var116 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var116 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						var91 += var92;
+						var115--;
+					} while (var115 > 0);
+				}
+			} else {
+				if (var93 > 0) {
+					do {
+						int var117;
+						if ((var117 = arg1[(var91 >>> 25) + (var91 & 0x3F80)]) != 0) {
+							arg0[var15] = ((var117 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var117 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						}
+						var15++;
+						int var118 = var91 + var92;
+						int var119;
+						if ((var119 = arg1[(var118 >>> 25) + (var118 & 0x3F80)]) != 0) {
+							arg0[var15] = ((var119 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var119 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						}
+						var15++;
+						int var120 = var92 + var118;
+						int var121;
+						if ((var121 = arg1[(var120 >>> 25) + (var120 & 0x3F80)]) != 0) {
+							arg0[var15] = ((var121 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var121 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						}
+						var15++;
+						int var122 = var92 + var120;
+						int var123;
+						if ((var123 = arg1[(var122 >>> 25) + (var122 & 0x3F80)]) != 0) {
+							arg0[var15] = ((var123 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var123 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						}
+						var15++;
+						int var124 = var92 + var122;
+						int var125;
+						if ((var125 = arg1[(var124 >>> 25) + (var124 & 0x3F80)]) != 0) {
+							arg0[var15] = ((var125 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var125 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						}
+						var15++;
+						int var126 = var92 + var124;
+						int var127;
+						if ((var127 = arg1[(var126 >>> 25) + (var126 & 0x3F80)]) != 0) {
+							arg0[var15] = ((var127 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var127 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						}
+						var15++;
+						int var128 = var92 + var126;
+						int var129;
+						if ((var129 = arg1[(var128 >>> 25) + (var128 & 0x3F80)]) != 0) {
+							arg0[var15] = ((var129 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var129 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						}
+						var15++;
+						int var130 = var92 + var128;
+						int var131;
+						if ((var131 = arg1[(var130 >>> 25) + (var130 & 0x3F80)]) != 0) {
+							arg0[var15] = ((var131 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var131 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						}
+						var15++;
+						var10000 = var92 + var130;
+						int var133 = var89;
+						int var134 = var90;
+						var85 += arg12;
+						var86 += arg13;
+						var87 += arg14;
+						int var135 = var87 >> 14;
+						if (var135 == 0) {
+							var89 = 0;
+							var90 = 0;
+						} else {
+							var89 = var85 / var135;
+							var90 = var86 / var135;
+							if (var89 < 0) {
+								var89 = 0;
+							} else if (var89 > 16256) {
+								var89 = 16256;
+							}
+						}
+						var91 = (var133 << 18) + var134;
+						var92 = (var89 - var133 >> 3 << 18) + (var90 - var134 >> 3);
+						var16 += var94;
+						var95 = var16 >> 8;
+						var93--;
+					} while (var93 > 0);
+				}
+				int var136 = arg6 - arg5 & 0x7;
+				if (var136 > 0) {
+					do {
+						int var137;
+						if ((var137 = arg1[(var91 >>> 25) + (var91 & 0x3F80)]) != 0) {
+							arg0[var15] = ((var137 & 0xFF00FF) * var95 & 0xFF00FF00) + ((var137 & 0xFF00) * var95 & 0xFF0000) >> 8;
+						}
+						var15++;
+						var91 += var92;
+						var136--;
+					} while (var136 > 0);
+				}
+			}
+			return;
+		}
+		int var18 = arg5 - originX;
+		int var19 = (arg12 >> 3) * var18 + arg9;
+		int var20 = (arg13 >> 3) * var18 + arg10;
+		int var21 = (arg14 >> 3) * var18 + arg11;
+		int var22 = var21 >> 12;
+		int var23;
+		int var24;
+		if (var22 == 0) {
+			var23 = 0;
+			var24 = 0;
+		} else {
+			var23 = var19 / var22;
+			var24 = var20 / var22;
+			if (var23 < 0) {
+				var23 = 0;
+			} else if (var23 > 4032) {
+				var23 = 4032;
+			}
+		}
+		int var25 = arg12 + var19;
+		int var26 = arg13 + var20;
+		int var27 = arg14 + var21;
+		int var28 = var27 >> 12;
+		int var29;
+		int var30;
+		if (var28 == 0) {
+			var29 = 0;
+			var30 = 0;
+		} else {
+			var29 = var25 / var28;
+			var30 = var26 / var28;
+			if (var29 < 0) {
+				var29 = 0;
+			} else if (var29 > 4032) {
+				var29 = 4032;
+			}
+		}
+		int var31 = (var23 << 20) + var24;
+		int var32 = (var29 - var23 >> 3 << 20) + (var30 - var24 >> 3);
+		int var33 = var17 >> 3;
+		int var34 = arg8 << 3;
+		int var35 = var16 >> 8;
+		if (opaque) {
+			if (var33 > 0) {
+				do {
+					int var36 = arg1[(var31 >>> 26) + (var31 & 0xFC0)];
+					arg0[var15++] = ((var36 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var36 & 0xFF00) * var35 & 0xFF0000) >> 8;
+					int var37 = var31 + var32;
+					int var38 = arg1[(var37 >>> 26) + (var37 & 0xFC0)];
+					arg0[var15++] = ((var38 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var38 & 0xFF00) * var35 & 0xFF0000) >> 8;
+					int var39 = var32 + var37;
+					int var40 = arg1[(var39 >>> 26) + (var39 & 0xFC0)];
+					arg0[var15++] = ((var40 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var40 & 0xFF00) * var35 & 0xFF0000) >> 8;
+					int var41 = var32 + var39;
+					int var42 = arg1[(var41 >>> 26) + (var41 & 0xFC0)];
+					arg0[var15++] = ((var42 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var42 & 0xFF00) * var35 & 0xFF0000) >> 8;
+					int var43 = var32 + var41;
+					int var44 = arg1[(var43 >>> 26) + (var43 & 0xFC0)];
+					arg0[var15++] = ((var44 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var44 & 0xFF00) * var35 & 0xFF0000) >> 8;
+					int var45 = var32 + var43;
+					int var46 = arg1[(var45 >>> 26) + (var45 & 0xFC0)];
+					arg0[var15++] = ((var46 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var46 & 0xFF00) * var35 & 0xFF0000) >> 8;
+					int var47 = var32 + var45;
+					int var48 = arg1[(var47 >>> 26) + (var47 & 0xFC0)];
+					arg0[var15++] = ((var48 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var48 & 0xFF00) * var35 & 0xFF0000) >> 8;
+					int var49 = var32 + var47;
+					int var50 = arg1[(var49 >>> 26) + (var49 & 0xFC0)];
+					arg0[var15++] = ((var50 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var50 & 0xFF00) * var35 & 0xFF0000) >> 8;
+					var10000 = var32 + var49;
+					int var52 = var29;
+					int var53 = var30;
+					var25 += arg12;
+					var26 += arg13;
+					var27 += arg14;
+					int var54 = var27 >> 12;
+					if (var54 == 0) {
+						var29 = 0;
+						var30 = 0;
+					} else {
+						var29 = var25 / var54;
+						var30 = var26 / var54;
+						if (var29 < 0) {
+							var29 = 0;
+						} else if (var29 > 4032) {
+							var29 = 4032;
+						}
+					}
+					var31 = (var52 << 20) + var53;
+					var32 = (var29 - var52 >> 3 << 20) + (var30 - var53 >> 3);
+					var16 += var34;
+					var35 = var16 >> 8;
+					var33--;
+				} while (var33 > 0);
+			}
+			int var55 = arg6 - arg5 & 0x7;
+			if (var55 > 0) {
+				do {
+					int var56 = arg1[(var31 >>> 26) + (var31 & 0xFC0)];
+					arg0[var15++] = ((var56 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var56 & 0xFF00) * var35 & 0xFF0000) >> 8;
+					var31 += var32;
+					var55--;
+				} while (var55 > 0);
+			}
+			return;
+		}
+		if (var33 > 0) {
+			do {
+				int var57;
+				if ((var57 = arg1[(var31 >>> 26) + (var31 & 0xFC0)]) != 0) {
+					arg0[var15] = ((var57 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var57 & 0xFF00) * var35 & 0xFF0000) >> 8;
+				}
+				var15++;
+				int var58 = var31 + var32;
+				int var59;
+				if ((var59 = arg1[(var58 >>> 26) + (var58 & 0xFC0)]) != 0) {
+					arg0[var15] = ((var59 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var59 & 0xFF00) * var35 & 0xFF0000) >> 8;
+				}
+				var15++;
+				int var60 = var32 + var58;
+				int var61;
+				if ((var61 = arg1[(var60 >>> 26) + (var60 & 0xFC0)]) != 0) {
+					arg0[var15] = ((var61 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var61 & 0xFF00) * var35 & 0xFF0000) >> 8;
+				}
+				var15++;
+				int var62 = var32 + var60;
+				int var63;
+				if ((var63 = arg1[(var62 >>> 26) + (var62 & 0xFC0)]) != 0) {
+					arg0[var15] = ((var63 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var63 & 0xFF00) * var35 & 0xFF0000) >> 8;
+				}
+				var15++;
+				int var64 = var32 + var62;
+				int var65;
+				if ((var65 = arg1[(var64 >>> 26) + (var64 & 0xFC0)]) != 0) {
+					arg0[var15] = ((var65 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var65 & 0xFF00) * var35 & 0xFF0000) >> 8;
+				}
+				var15++;
+				int var66 = var32 + var64;
+				int var67;
+				if ((var67 = arg1[(var66 >>> 26) + (var66 & 0xFC0)]) != 0) {
+					arg0[var15] = ((var67 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var67 & 0xFF00) * var35 & 0xFF0000) >> 8;
+				}
+				var15++;
+				int var68 = var32 + var66;
+				int var69;
+				if ((var69 = arg1[(var68 >>> 26) + (var68 & 0xFC0)]) != 0) {
+					arg0[var15] = ((var69 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var69 & 0xFF00) * var35 & 0xFF0000) >> 8;
+				}
+				var15++;
+				int var70 = var32 + var68;
+				int var71;
+				if ((var71 = arg1[(var70 >>> 26) + (var70 & 0xFC0)]) != 0) {
+					arg0[var15] = ((var71 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var71 & 0xFF00) * var35 & 0xFF0000) >> 8;
+				}
+				var15++;
+				var10000 = var32 + var70;
+				int var73 = var29;
+				int var74 = var30;
+				var25 += arg12;
+				var26 += arg13;
+				var27 += arg14;
+				int var75 = var27 >> 12;
+				if (var75 == 0) {
+					var29 = 0;
+					var30 = 0;
+				} else {
+					var29 = var25 / var75;
+					var30 = var26 / var75;
+					if (var29 < 0) {
+						var29 = 0;
+					} else if (var29 > 4032) {
+						var29 = 4032;
+					}
+				}
+				var31 = (var73 << 20) + var74;
+				var32 = (var29 - var73 >> 3 << 20) + (var30 - var74 >> 3);
+				var16 += var34;
+				var35 = var16 >> 8;
+				var33--;
+			} while (var33 > 0);
+		}
+		int var76 = arg6 - arg5 & 0x7;
+		if (var76 <= 0) {
+			return;
+		}
+		do {
+			int var77;
+			if ((var77 = arg1[(var31 >>> 26) + (var31 & 0xFC0)]) != 0) {
+				arg0[var15] = ((var77 & 0xFF00FF) * var35 & 0xFF00FF00) + ((var77 & 0xFF00) * var35 & 0xFF0000) >> 8;
+			}
+			var15++;
+			var31 += var32;
+			var76--;
+		} while (var76 > 0);
+	}
+
+	@ObfuscatedName("fx.co(IIIIIIIIIIIIIIIIIII)V")
+	public static void textureTriangleCorrect(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14, int arg15, int arg16, int arg17, int arg18) {
+		int[] var19 = textureProvider.getTexels(arg18);
+		if (var19 == null) {
+			int var20 = textureProvider.getAverageRgb(arg18);
+			gouraudTriangle(arg0, arg1, arg2, arg3, arg4, arg5, textureLightColour(var20, arg6), textureLightColour(var20, arg7), textureLightColour(var20, arg8));
+			return;
+		}
+		lowMem = textureProvider.isLowMem(arg18);
+		opaque = textureProvider.isOpaque(arg18);
+		int var21 = arg4 - arg3;
+		int var22 = arg1 - arg0;
+		int var23 = arg5 - arg3;
+		int var24 = arg2 - arg0;
+		int var25 = arg7 - arg6;
+		int var26 = arg8 - arg6;
+		int var27 = 0;
+		if (arg0 != arg1) {
+			var27 = (arg4 - arg3 << 16) / (arg1 - arg0);
+		}
+		int var28 = 0;
+		if (arg1 != arg2) {
+			var28 = (arg5 - arg4 << 16) / (arg2 - arg1);
+		}
+		int var29 = 0;
+		if (arg0 != arg2) {
+			var29 = (arg3 - arg5 << 16) / (arg0 - arg2);
+		}
+		int var30 = var21 * var24 - var22 * var23;
+		if (var30 == 0) {
+			return;
+		}
+		int var31 = (var24 * var25 - var22 * var26 << 9) / var30;
+		int var32 = (var21 * var26 - var23 * var25 << 9) / var30;
+		int var33 = arg9 - arg10;
+		int var34 = arg12 - arg13;
+		int var35 = arg15 - arg16;
+		int var36 = arg11 - arg9;
+		int var37 = arg14 - arg12;
+		int var38 = arg17 - arg15;
+		int var39 = arg12 * var36 - arg9 * var37 << 14;
+		int var40 = arg15 * var37 - arg12 * var38 << 5;
+		int var41 = arg9 * var38 - arg15 * var36 << 5;
+		int var42 = arg12 * var33 - arg9 * var34 << 14;
+		int var43 = arg15 * var34 - arg12 * var35 << 5;
+		int var44 = arg9 * var35 - arg15 * var33 << 5;
+		int var45 = var34 * var36 - var33 * var37 << 14;
+		int var46 = var35 * var37 - var34 * var38 << 5;
+		int var47 = var33 * var38 - var35 * var36 << 5;
+		if (arg0 <= arg1 && arg0 <= arg2) {
+			if (arg0 < sizeY) {
+				if (arg1 > sizeY) {
+					arg1 = sizeY;
+				}
+				if (arg2 > sizeY) {
+					arg2 = sizeY;
+				}
+				int var48 = (arg6 << 9) - arg3 * var31 + var31;
+				if (arg1 < arg2) {
+					int var49;
+					int var50 = var49 = arg3 << 16;
+					if (arg0 < 0) {
+						var50 -= arg0 * var29;
+						var49 -= arg0 * var27;
+						var48 -= arg0 * var32;
+						arg0 = 0;
+					}
+					int var51 = arg4 << 16;
+					if (arg1 < 0) {
+						var51 -= arg1 * var28;
+						arg1 = 0;
+					}
+					int var52 = arg0 - originY;
+					int var53 = var41 * var52 + var39;
+					int var54 = var44 * var52 + var42;
+					int var55 = var47 * var52 + var45;
+					if (arg0 != arg1 && var29 < var27 || arg0 == arg1 && var29 > var28) {
+						int var56 = arg2 - arg1;
+						int var57 = arg1 - arg0;
+						int var58 = scanline[arg0];
+						while (true) {
+							var57--;
+							if (var57 < 0) {
+								while (true) {
+									var56--;
+									if (var56 < 0) {
+										return;
+									}
+									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var58, var50 >> 16, var51 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
+									var50 += var29;
+									var51 += var28;
+									var48 += var32;
+									var58 += Pix2D.width;
+									var53 += var41;
+									var54 += var44;
+									var55 += var47;
+								}
+							}
+							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var58, var50 >> 16, var49 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
+							var50 += var29;
+							var49 += var27;
+							var48 += var32;
+							var58 += Pix2D.width;
+							var53 += var41;
+							var54 += var44;
+							var55 += var47;
+						}
+					} else {
+						int var59 = arg2 - arg1;
+						int var60 = arg1 - arg0;
+						int var61 = scanline[arg0];
+						while (true) {
+							var60--;
+							if (var60 < 0) {
+								while (true) {
+									var59--;
+									if (var59 < 0) {
+										return;
+									}
+									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var61, var51 >> 16, var50 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
+									var50 += var29;
+									var51 += var28;
+									var48 += var32;
+									var61 += Pix2D.width;
+									var53 += var41;
+									var54 += var44;
+									var55 += var47;
+								}
+							}
+							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var61, var49 >> 16, var50 >> 16, var48, var31, var53, var54, var55, var40, var43, var46);
+							var50 += var29;
+							var49 += var27;
+							var48 += var32;
+							var61 += Pix2D.width;
+							var53 += var41;
+							var54 += var44;
+							var55 += var47;
+						}
+					}
+				} else {
+					int var62;
+					int var63 = var62 = arg3 << 16;
+					if (arg0 < 0) {
+						var63 -= arg0 * var29;
+						var62 -= arg0 * var27;
+						var48 -= arg0 * var32;
+						arg0 = 0;
+					}
+					int var64 = arg5 << 16;
+					if (arg2 < 0) {
+						var64 -= arg2 * var28;
+						arg2 = 0;
+					}
+					int var65 = arg0 - originY;
+					int var66 = var41 * var65 + var39;
+					int var67 = var44 * var65 + var42;
+					int var68 = var47 * var65 + var45;
+					if ((arg0 == arg2 || var29 >= var27) && (arg0 != arg2 || var28 <= var27)) {
+						int var72 = arg1 - arg2;
+						int var73 = arg2 - arg0;
+						int var74 = scanline[arg0];
+						while (true) {
+							var73--;
+							if (var73 < 0) {
+								while (true) {
+									var72--;
+									if (var72 < 0) {
+										return;
+									}
+									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var74, var62 >> 16, var64 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
+									var64 += var28;
+									var62 += var27;
+									var48 += var32;
+									var74 += Pix2D.width;
+									var66 += var41;
+									var67 += var44;
+									var68 += var47;
+								}
+							}
+							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var74, var62 >> 16, var63 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
+							var63 += var29;
+							var62 += var27;
+							var48 += var32;
+							var74 += Pix2D.width;
+							var66 += var41;
+							var67 += var44;
+							var68 += var47;
+						}
+					} else {
+						int var69 = arg1 - arg2;
+						int var70 = arg2 - arg0;
+						int var71 = scanline[arg0];
+						while (true) {
+							var70--;
+							if (var70 < 0) {
+								while (true) {
+									var69--;
+									if (var69 < 0) {
+										return;
+									}
+									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var71, var64 >> 16, var62 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
+									var64 += var28;
+									var62 += var27;
+									var48 += var32;
+									var71 += Pix2D.width;
+									var66 += var41;
+									var67 += var44;
+									var68 += var47;
+								}
+							}
+							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var71, var63 >> 16, var62 >> 16, var48, var31, var66, var67, var68, var40, var43, var46);
+							var63 += var29;
+							var62 += var27;
+							var48 += var32;
+							var71 += Pix2D.width;
+							var66 += var41;
+							var67 += var44;
+							var68 += var47;
+						}
+					}
+				}
+			}
+		} else if (arg1 <= arg2) {
+			if (arg1 < sizeY) {
+				if (arg2 > sizeY) {
+					arg2 = sizeY;
+				}
+				if (arg0 > sizeY) {
+					arg0 = sizeY;
+				}
+				int var75 = (arg7 << 9) - arg4 * var31 + var31;
+				if (arg2 < arg0) {
+					int var76;
+					int var77 = var76 = arg4 << 16;
+					if (arg1 < 0) {
+						var77 -= arg1 * var27;
+						var76 -= arg1 * var28;
+						var75 -= arg1 * var32;
+						arg1 = 0;
+					}
+					int var78 = arg5 << 16;
+					if (arg2 < 0) {
+						var78 -= arg2 * var29;
+						arg2 = 0;
+					}
+					int var79 = arg1 - originY;
+					int var80 = var41 * var79 + var39;
+					int var81 = var44 * var79 + var42;
+					int var82 = var47 * var79 + var45;
+					if (arg1 != arg2 && var27 < var28 || arg1 == arg2 && var27 > var29) {
+						int var83 = arg0 - arg2;
+						int var84 = arg2 - arg1;
+						int var85 = scanline[arg1];
+						while (true) {
+							var84--;
+							if (var84 < 0) {
+								while (true) {
+									var83--;
+									if (var83 < 0) {
+										return;
+									}
+									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var85, var77 >> 16, var78 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
+									var77 += var27;
+									var78 += var29;
+									var75 += var32;
+									var85 += Pix2D.width;
+									var80 += var41;
+									var81 += var44;
+									var82 += var47;
+								}
+							}
+							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var85, var77 >> 16, var76 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
+							var77 += var27;
+							var76 += var28;
+							var75 += var32;
+							var85 += Pix2D.width;
+							var80 += var41;
+							var81 += var44;
+							var82 += var47;
+						}
+					} else {
+						int var86 = arg0 - arg2;
+						int var87 = arg2 - arg1;
+						int var88 = scanline[arg1];
+						while (true) {
+							var87--;
+							if (var87 < 0) {
+								while (true) {
+									var86--;
+									if (var86 < 0) {
+										return;
+									}
+									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var88, var78 >> 16, var77 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
+									var77 += var27;
+									var78 += var29;
+									var75 += var32;
+									var88 += Pix2D.width;
+									var80 += var41;
+									var81 += var44;
+									var82 += var47;
+								}
+							}
+							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var88, var76 >> 16, var77 >> 16, var75, var31, var80, var81, var82, var40, var43, var46);
+							var77 += var27;
+							var76 += var28;
+							var75 += var32;
+							var88 += Pix2D.width;
+							var80 += var41;
+							var81 += var44;
+							var82 += var47;
+						}
+					}
+				} else {
+					int var89;
+					int var90 = var89 = arg4 << 16;
+					if (arg1 < 0) {
+						var90 -= arg1 * var27;
+						var89 -= arg1 * var28;
+						var75 -= arg1 * var32;
+						arg1 = 0;
+					}
+					int var91 = arg3 << 16;
+					if (arg0 < 0) {
+						var91 -= arg0 * var29;
+						arg0 = 0;
+					}
+					int var92 = arg1 - originY;
+					int var93 = var41 * var92 + var39;
+					int var94 = var44 * var92 + var42;
+					int var95 = var47 * var92 + var45;
+					if (var27 < var28) {
+						int var96 = arg2 - arg0;
+						int var97 = arg0 - arg1;
+						int var98 = scanline[arg1];
+						while (true) {
+							var97--;
+							if (var97 < 0) {
+								while (true) {
+									var96--;
+									if (var96 < 0) {
+										return;
+									}
+									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var98, var91 >> 16, var89 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
+									var91 += var29;
+									var89 += var28;
+									var75 += var32;
+									var98 += Pix2D.width;
+									var93 += var41;
+									var94 += var44;
+									var95 += var47;
+								}
+							}
+							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var98, var90 >> 16, var89 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
+							var90 += var27;
+							var89 += var28;
+							var75 += var32;
+							var98 += Pix2D.width;
+							var93 += var41;
+							var94 += var44;
+							var95 += var47;
+						}
+					} else {
+						int var99 = arg2 - arg0;
+						int var100 = arg0 - arg1;
+						int var101 = scanline[arg1];
+						while (true) {
+							var100--;
+							if (var100 < 0) {
+								while (true) {
+									var99--;
+									if (var99 < 0) {
+										return;
+									}
+									textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var101, var89 >> 16, var91 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
+									var91 += var29;
+									var89 += var28;
+									var75 += var32;
+									var101 += Pix2D.width;
+									var93 += var41;
+									var94 += var44;
+									var95 += var47;
+								}
+							}
+							textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var101, var89 >> 16, var90 >> 16, var75, var31, var93, var94, var95, var40, var43, var46);
+							var90 += var27;
+							var89 += var28;
+							var75 += var32;
+							var101 += Pix2D.width;
+							var93 += var41;
+							var94 += var44;
+							var95 += var47;
+						}
+					}
+				}
+			}
+		} else if (arg2 < sizeY) {
+			if (arg0 > sizeY) {
+				arg0 = sizeY;
+			}
+			if (arg1 > sizeY) {
+				arg1 = sizeY;
+			}
+			int var102 = (arg8 << 9) - arg5 * var31 + var31;
+			if (arg0 < arg1) {
+				int var103;
+				int var104 = var103 = arg5 << 16;
+				if (arg2 < 0) {
+					var104 -= arg2 * var28;
+					var103 -= arg2 * var29;
+					var102 -= arg2 * var32;
+					arg2 = 0;
+				}
+				int var105 = arg3 << 16;
+				if (arg0 < 0) {
+					var105 -= arg0 * var27;
+					arg0 = 0;
+				}
+				int var106 = arg2 - originY;
+				int var107 = var41 * var106 + var39;
+				int var108 = var44 * var106 + var42;
+				int var109 = var47 * var106 + var45;
+				if (var28 < var29) {
+					int var110 = arg1 - arg0;
+					int var111 = arg0 - arg2;
+					int var112 = scanline[arg2];
+					while (true) {
+						var111--;
+						if (var111 < 0) {
+							while (true) {
+								var110--;
+								if (var110 < 0) {
+									return;
+								}
+								textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var112, var104 >> 16, var105 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
+								var104 += var28;
+								var105 += var27;
+								var102 += var32;
+								var112 += Pix2D.width;
+								var107 += var41;
+								var108 += var44;
+								var109 += var47;
+							}
+						}
+						textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var112, var104 >> 16, var103 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
+						var104 += var28;
+						var103 += var29;
+						var102 += var32;
+						var112 += Pix2D.width;
+						var107 += var41;
+						var108 += var44;
+						var109 += var47;
+					}
+				} else {
+					int var113 = arg1 - arg0;
+					int var114 = arg0 - arg2;
+					int var115 = scanline[arg2];
+					while (true) {
+						var114--;
+						if (var114 < 0) {
+							while (true) {
+								var113--;
+								if (var113 < 0) {
+									return;
+								}
+								textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var115, var105 >> 16, var104 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
+								var104 += var28;
+								var105 += var27;
+								var102 += var32;
+								var115 += Pix2D.width;
+								var107 += var41;
+								var108 += var44;
+								var109 += var47;
+							}
+						}
+						textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var115, var103 >> 16, var104 >> 16, var102, var31, var107, var108, var109, var40, var43, var46);
+						var104 += var28;
+						var103 += var29;
+						var102 += var32;
+						var115 += Pix2D.width;
+						var107 += var41;
+						var108 += var44;
+						var109 += var47;
+					}
+				}
+			} else {
+				int var116;
+				int var117 = var116 = arg5 << 16;
+				if (arg2 < 0) {
+					var117 -= arg2 * var28;
+					var116 -= arg2 * var29;
+					var102 -= arg2 * var32;
+					arg2 = 0;
+				}
+				int var118 = arg4 << 16;
+				if (arg1 < 0) {
+					var118 -= arg1 * var27;
+					arg1 = 0;
+				}
+				int var119 = arg2 - originY;
+				int var120 = var41 * var119 + var39;
+				int var121 = var44 * var119 + var42;
+				int var122 = var47 * var119 + var45;
+				if (var28 < var29) {
+					int var123 = arg0 - arg1;
+					int var124 = arg1 - arg2;
+					int var125 = scanline[arg2];
+					while (true) {
+						var124--;
+						if (var124 < 0) {
+							while (true) {
+								var123--;
+								if (var123 < 0) {
+									return;
+								}
+								textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var125, var118 >> 16, var116 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
+								var118 += var27;
+								var116 += var29;
+								var102 += var32;
+								var125 += Pix2D.width;
+								var120 += var41;
+								var121 += var44;
+								var122 += var47;
+							}
+						}
+						textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var125, var117 >> 16, var116 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
+						var117 += var28;
+						var116 += var29;
+						var102 += var32;
+						var125 += Pix2D.width;
+						var120 += var41;
+						var121 += var44;
+						var122 += var47;
+					}
+				} else {
+					int var126 = arg0 - arg1;
+					int var127 = arg1 - arg2;
+					int var128 = scanline[arg2];
+					while (true) {
+						var127--;
+						if (var127 < 0) {
+							while (true) {
+								var126--;
+								if (var126 < 0) {
+									return;
+								}
+								textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var128, var116 >> 16, var118 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
+								var118 += var27;
+								var116 += var29;
+								var102 += var32;
+								var128 += Pix2D.width;
+								var120 += var41;
+								var121 += var44;
+								var122 += var47;
+							}
+						}
+						textureRasterCorrect(Pix2D.pixels, var19, 0, 0, var128, var116 >> 16, var117 >> 16, var102, var31, var120, var121, var122, var40, var43, var46);
+						var117 += var28;
+						var116 += var29;
+						var102 += var32;
+						var128 += Pix2D.width;
+						var120 += var41;
+						var121 += var44;
+						var122 += var47;
+					}
+				}
+			}
+		}
+	}
+
+	@ObfuscatedName("fx.ch([I[IIIIIIIIIIIIII)V")
+	public static void textureRasterCorrect(int[] arg0, int[] arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11, int arg12, int arg13, int arg14) {
 		if (hclip) {
 			if (arg6 > sizeX) {
 				arg6 = sizeX;

--- a/src/main/java/jagex3/dash3d/World.java
+++ b/src/main/java/jagex3/dash3d/World.java
@@ -1744,9 +1744,9 @@ public class World {
 				int textureColor = Pix3D.textureProvider.getAverageRgb(underlay.texture);
 				Pix3D.gouraudTriangle(pz1, py3, px1, py1, px3, pz0, mulLightness(textureColor, underlay.colourNE), mulLightness(textureColor, underlay.colourNW), mulLightness(textureColor, underlay.colourSE));
 			} else if (underlay.flat) {
-				Pix3D.textureTriangle(pz1, py3, px1, py1, px3, pz0, underlay.colourNE, underlay.colourNW, underlay.colourSE, var21, var27, var39, var24, var30, var42, z0, z1, z3, underlay.texture);
+				Pix3D.textureTriangleCorrect(pz1, py3, px1, py1, px3, pz0, underlay.colourNE, underlay.colourNW, underlay.colourSE, var21, var27, var39, var24, var30, var42, z0, z1, z3, underlay.texture);
 			} else {
-				Pix3D.textureTriangle(pz1, py3, px1, py1, px3, pz0, underlay.colourNE, underlay.colourNW, underlay.colourSE, var33, var39, var27, var36, var42, var30, z2, z3, z1, underlay.texture);
+				Pix3D.textureTriangleCorrect(pz1, py3, px1, py1, px3, pz0, underlay.colourNE, underlay.colourNW, underlay.colourSE, var33, var39, var27, var36, var42, var30, z2, z3, z1, underlay.texture);
 			}
 		}
 
@@ -1769,7 +1769,7 @@ public class World {
 				int averageColour = Pix3D.textureProvider.getAverageRgb(underlay.texture);
 				Pix3D.gouraudTriangle(py0, px1, py3, px0, pz0, px3, mulLightness(averageColour, underlay.colourSW), mulLightness(averageColour, underlay.colourSE), mulLightness(averageColour, underlay.colourNW));
 			} else {
-				Pix3D.textureTriangle(py0, px1, py3, px0, pz0, px3, underlay.colourSW, underlay.colourSE, underlay.colourNW, var21, var27, var39, var24, var30, var42, z0, z1, z3, underlay.texture);
+				Pix3D.textureTriangleCorrect(py0, px1, py3, px0, pz0, px3, underlay.colourSW, underlay.colourSE, underlay.colourNW, var21, var27, var39, var24, var30, var42, z0, z1, z3, underlay.texture);
 			}
 		}
 	}
@@ -1838,9 +1838,9 @@ public class World {
 					int textureColor = Pix3D.textureProvider.getAverageRgb(overlay.faceTexture[var20]);
 					Pix3D.gouraudTriangle(yA, yB, yC, xA, xB, xC, mulLightness(textureColor, overlay.faceColourA[var20]), mulLightness(textureColor, overlay.faceColourB[var20]), mulLightness(textureColor, overlay.faceColourC[var20]));
 				} else if (overlay.flat) {
-					Pix3D.textureTriangle(yA, yB, yC, xA, xB, xC, overlay.faceColourA[var20], overlay.faceColourB[var20], overlay.faceColourC[var20], Ground.drawTextureVertexX[0], Ground.drawTextureVertexX[1], Ground.drawTextureVertexX[3], Ground.drawTextureVertexY[0], Ground.drawTextureVertexY[1], Ground.drawTextureVertexY[3], Ground.drawTextureVertexZ[0], Ground.drawTextureVertexZ[1], Ground.drawTextureVertexZ[3], overlay.faceTexture[var20]);
+					Pix3D.textureTriangleCorrect(yA, yB, yC, xA, xB, xC, overlay.faceColourA[var20], overlay.faceColourB[var20], overlay.faceColourC[var20], Ground.drawTextureVertexX[0], Ground.drawTextureVertexX[1], Ground.drawTextureVertexX[3], Ground.drawTextureVertexY[0], Ground.drawTextureVertexY[1], Ground.drawTextureVertexY[3], Ground.drawTextureVertexZ[0], Ground.drawTextureVertexZ[1], Ground.drawTextureVertexZ[3], overlay.faceTexture[var20]);
 				} else {
-					Pix3D.textureTriangle(yA, yB, yC, xA, xB, xC, overlay.faceColourA[var20], overlay.faceColourB[var20], overlay.faceColourC[var20], Ground.drawTextureVertexX[a], Ground.drawTextureVertexX[b], Ground.drawTextureVertexX[c], Ground.drawTextureVertexY[a], Ground.drawTextureVertexY[b], Ground.drawTextureVertexY[c], Ground.drawTextureVertexZ[a], Ground.drawTextureVertexZ[b], Ground.drawTextureVertexZ[c], overlay.faceTexture[var20]);
+					Pix3D.textureTriangleCorrect(yA, yB, yC, xA, xB, xC, overlay.faceColourA[var20], overlay.faceColourB[var20], overlay.faceColourC[var20], Ground.drawTextureVertexX[a], Ground.drawTextureVertexX[b], Ground.drawTextureVertexX[c], Ground.drawTextureVertexY[a], Ground.drawTextureVertexY[b], Ground.drawTextureVertexY[c], Ground.drawTextureVertexZ[a], Ground.drawTextureVertexZ[b], Ground.drawTextureVertexZ[c], overlay.faceTexture[var20]);
 				}
 			}
 		}

--- a/src/main/java/jagex3/dash3d/World.java
+++ b/src/main/java/jagex3/dash3d/World.java
@@ -1744,9 +1744,9 @@ public class World {
 				int textureColor = Pix3D.textureProvider.getAverageRgb(underlay.texture);
 				Pix3D.gouraudTriangle(pz1, py3, px1, py1, px3, pz0, mulLightness(textureColor, underlay.colourNE), mulLightness(textureColor, underlay.colourNW), mulLightness(textureColor, underlay.colourSE));
 			} else if (underlay.flat) {
-				Pix3D.textureTriangleCorrect(pz1, py3, px1, py1, px3, pz0, underlay.colourNE, underlay.colourNW, underlay.colourSE, var21, var27, var39, var24, var30, var42, z0, z1, z3, underlay.texture);
+				Pix3D.textureTriangleAffine(pz1, py3, px1, py1, px3, pz0, underlay.colourNE, underlay.colourNW, underlay.colourSE, var21, var27, var39, var24, var30, var42, z0, z1, z3, underlay.texture);
 			} else {
-				Pix3D.textureTriangleCorrect(pz1, py3, px1, py1, px3, pz0, underlay.colourNE, underlay.colourNW, underlay.colourSE, var33, var39, var27, var36, var42, var30, z2, z3, z1, underlay.texture);
+				Pix3D.textureTriangleAffine(pz1, py3, px1, py1, px3, pz0, underlay.colourNE, underlay.colourNW, underlay.colourSE, var33, var39, var27, var36, var42, var30, z2, z3, z1, underlay.texture);
 			}
 		}
 
@@ -1769,7 +1769,7 @@ public class World {
 				int averageColour = Pix3D.textureProvider.getAverageRgb(underlay.texture);
 				Pix3D.gouraudTriangle(py0, px1, py3, px0, pz0, px3, mulLightness(averageColour, underlay.colourSW), mulLightness(averageColour, underlay.colourSE), mulLightness(averageColour, underlay.colourNW));
 			} else {
-				Pix3D.textureTriangleCorrect(py0, px1, py3, px0, pz0, px3, underlay.colourSW, underlay.colourSE, underlay.colourNW, var21, var27, var39, var24, var30, var42, z0, z1, z3, underlay.texture);
+				Pix3D.textureTriangleAffine(py0, px1, py3, px0, pz0, px3, underlay.colourSW, underlay.colourSE, underlay.colourNW, var21, var27, var39, var24, var30, var42, z0, z1, z3, underlay.texture);
 			}
 		}
 	}
@@ -1838,9 +1838,9 @@ public class World {
 					int textureColor = Pix3D.textureProvider.getAverageRgb(overlay.faceTexture[var20]);
 					Pix3D.gouraudTriangle(yA, yB, yC, xA, xB, xC, mulLightness(textureColor, overlay.faceColourA[var20]), mulLightness(textureColor, overlay.faceColourB[var20]), mulLightness(textureColor, overlay.faceColourC[var20]));
 				} else if (overlay.flat) {
-					Pix3D.textureTriangleCorrect(yA, yB, yC, xA, xB, xC, overlay.faceColourA[var20], overlay.faceColourB[var20], overlay.faceColourC[var20], Ground.drawTextureVertexX[0], Ground.drawTextureVertexX[1], Ground.drawTextureVertexX[3], Ground.drawTextureVertexY[0], Ground.drawTextureVertexY[1], Ground.drawTextureVertexY[3], Ground.drawTextureVertexZ[0], Ground.drawTextureVertexZ[1], Ground.drawTextureVertexZ[3], overlay.faceTexture[var20]);
+					Pix3D.textureTriangleAffine(yA, yB, yC, xA, xB, xC, overlay.faceColourA[var20], overlay.faceColourB[var20], overlay.faceColourC[var20], Ground.drawTextureVertexX[0], Ground.drawTextureVertexX[1], Ground.drawTextureVertexX[3], Ground.drawTextureVertexY[0], Ground.drawTextureVertexY[1], Ground.drawTextureVertexY[3], Ground.drawTextureVertexZ[0], Ground.drawTextureVertexZ[1], Ground.drawTextureVertexZ[3], overlay.faceTexture[var20]);
 				} else {
-					Pix3D.textureTriangleCorrect(yA, yB, yC, xA, xB, xC, overlay.faceColourA[var20], overlay.faceColourB[var20], overlay.faceColourC[var20], Ground.drawTextureVertexX[a], Ground.drawTextureVertexX[b], Ground.drawTextureVertexX[c], Ground.drawTextureVertexY[a], Ground.drawTextureVertexY[b], Ground.drawTextureVertexY[c], Ground.drawTextureVertexZ[a], Ground.drawTextureVertexZ[b], Ground.drawTextureVertexZ[c], overlay.faceTexture[var20]);
+					Pix3D.textureTriangleAffine(yA, yB, yC, xA, xB, xC, overlay.faceColourA[var20], overlay.faceColourB[var20], overlay.faceColourC[var20], Ground.drawTextureVertexX[a], Ground.drawTextureVertexX[b], Ground.drawTextureVertexX[c], Ground.drawTextureVertexY[a], Ground.drawTextureVertexY[b], Ground.drawTextureVertexY[c], Ground.drawTextureVertexZ[a], Ground.drawTextureVertexZ[b], Ground.drawTextureVertexZ[c], overlay.faceTexture[var20]);
 				}
 			}
 		}


### PR DESCRIPTION
Looks like textureTriangleAffine is used for ground. This is consistent with what I see in OSRS.